### PR TITLE
When adding a moment, include the storyline suggested by GPT

### DIFF
--- a/src/app_load.tsx
+++ b/src/app_load.tsx
@@ -6,13 +6,25 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { createRoot } from "react-dom/client";
 import { ReactApp } from "./react/ux.js";
-import { appTreeConfiguration, Life2, newAppTreeConfiguration } from "./schema/app_schema.js";
+import { appTreeConfiguration, Life2, Moments, newAppTreeConfiguration } from "./schema/app_schema.js";
 import { sessionTreeConfiguration } from "./schema/session_schema.js";
 import { createUndoRedoStacks } from "./utils/undo.js";
 import { loadFluidData } from "./infra/fluid.js";
 import { containerSchema } from "./schema/container_schema.js";
 import { PublicClientApplication } from "@azure/msal-browser";
 import { GPTService } from "./services/gptService.js";
+
+export const sampleData = [
+	{ moment: "I ate a cheeseburger", storyline: "food and symptom log" },
+	{ moment: "I got a headache", storyline: "food and symptom log" },
+	{ moment: "I had a mild sore throat this morning", storyline: "food and symptom log" },
+	{ moment: "We landed in France!", storyline: "vacation log" },
+	{
+		moment: "We met up with Pierre and Yvonne at a cafe in Paris",
+		storyline: "vacation log",
+	},
+	{ moment: "We went to the Louvre this afternoon", storyline: "vacation log" },
+];
 
 export async function loadApp(
 	client: AzureClient | OdspClient,
@@ -32,8 +44,11 @@ export async function loadApp(
 	}
 
 	const appTree = container.initialObjects.appData.viewWith(appTreeConfiguration);
-	if (appTree.compatibility.canInitialize)
-		appTree.initialize({ name: "Life", moment: [], days: [], sessionsPerDay: 4 });
+	if (appTree.compatibility.canInitialize) {
+		const sampleMoments: Moments = new Moments([]);
+		sampleData.forEach(({ moment, storyline }) => sampleMoments.addMoment(moment, storyline));
+		appTree.initialize({ name: "Life", moment: sampleMoments, days: [], sessionsPerDay: 4 });
+	}
 
 	// create the root element for React
 	const app = document.createElement("div");

--- a/src/schema/app_schema.ts
+++ b/src/schema/app_schema.ts
@@ -7,8 +7,6 @@ import {
 	TreeViewConfiguration,
 	SchemaFactory,
 	Tree,
-	TreeNode,
-	TreeArrayNode,
 	InsertableTypedNode,
 } from "fluid-framework";
 import { v4 as uuid } from "uuid";
@@ -31,13 +29,6 @@ export class Tag extends sf.object(
 		this.name = name;
 	}
 }
-
-const MomentType = {
-	session: "Session",
-	workshop: "Workshop",
-	panel: "Panel",
-	keynote: "Keynote",
-};
 
 export class Moment extends sf.object("Moment", {
 	id: sf.identifier,
@@ -93,7 +84,7 @@ export class Moment extends sf.object("Moment", {
 
 export class Moments extends sf.array("Moments", Moment) {
 	// Add a moment to the life
-	public addSession(description?: string) {
+	public addMoment(description?: string, storyline?: string) {
 		const currentTime = new Date().getTime();
 		if (description === undefined) {
 			description = "New Session";
@@ -104,7 +95,7 @@ export class Moments extends sf.array("Moments", Moment) {
 			additionalNotes: "Add a description",
 			created: currentTime,
 			lastChanged: currentTime,
-			storyLineIds: [],
+			storyLineIds: storyline ? [storyline] : [],
 		});
 		this.insertAtEnd(moment);
 		return moment;

--- a/src/services/gptService.ts
+++ b/src/services/gptService.ts
@@ -4,6 +4,7 @@ import { ChatCompletionCreateParamsNonStreaming } from "openai/resources/index.m
 import { PublicClientApplication } from "@azure/msal-browser";
 import { Moment } from "../schema/app_schema.js";
 import { getAccessToken, getSessionToken } from "../utils/auth_helpers.js";
+import { sampleData } from "../app_load.js";
 
 export class GPTService {
 	private static _instance: GPTService;
@@ -108,23 +109,10 @@ function createSessionPrompter(
 		apiVersion: "2024-08-01-preview",
 	});
 
-	const samples = JSON.stringify([
-		{ moment: "I ate a cheeseburger", storyline: "food and symptom log" },
-		{ moment: "I got a headache", storyline: "food and symptom log" },
-		{ moment: "I had a mild sore throat this morning", storyline: "food and symptom log" },
-		{ moment: "We landed in France!", storyline: "vacation log" },
-		{
-			moment: "We met up with Pierre and Yvonne at a cafe in Paris",
-			storyline: "vacation log",
-		},
-		{ moment: "We went to the Louvre this afternoon", storyline: "vacation log" },
-	]);
-
-	//* TODO: Do we need to replay these 3 messages with each prompt, or is there context that's remembered?
 	const bodyBase: ChatCompletionCreateParamsNonStreaming = {
 		messages: [
 			{ role: "system", content: sessionSystemPrompt },
-			{ role: "system", content: samples },
+			{ role: "system", content: JSON.stringify(sampleData) },
 			{
 				role: "user",
 				content:


### PR DESCRIPTION
This updates gptService to get the chat response in a specified JSON schema, which includes the suggested storyline and whether it's an existing one (from the input "sample" data) or a new one. Then the storyline value is added to `storylineIds`.

This last part obviously doesn't match the new `Life2` schema, but it works for the current setup.

------------------

Example of matching the existing (sample) storylines:
![image](https://github.com/user-attachments/assets/31ffff4e-f5bb-4d36-b6a6-d28cd713d604)

Example of suggesting a new storyline:
![image](https://github.com/user-attachments/assets/1b774968-58e1-4265-b795-5979de080939)


Note that "existing" here means "found in the sample data".  Next step would be to feed the whole set of moments into each prompt, so "existing" means what it says.
